### PR TITLE
Updated shadowjar plugin to version 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.1'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 group 'com.refactify'


### PR DESCRIPTION
FIX: Updated shadowjar plugin to version 1.2.3 which is required by Gradle 2.11, https://stackoverflow.com/questions/35343589/could-not-create-task-of-type-shadowjar